### PR TITLE
Fix MigrateRequiredHasManyOp

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -489,7 +489,7 @@ export async function upgrade(input: Input): Promise<Output> {
     }
     const hasOne = edge1.type === "hasOne" ? edge1 : edge2
     // skip over ops that have already been applied
-    const p2Field = prisma2.findField((m, f) => hasOne.from.name === m.name && hasOne.to.name === f.name)
+    const p2Field = prisma2.findField((m, f) => hasOne.from.name === m.name && hasOne.fromField.name === f.name)
     if (!p2Field || !p2Field.type.optional()) {
       continue
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -367,6 +367,13 @@ async function main(argv: string[]): Promise<void> {
             console.log()
             console.log()
             break
+          case "MigrateRequiredHasManyOp":
+            console.log(`  ${bold(`Fix required one-to-many table relations`)}`);
+            console.log();
+            console.log(redent(queries.join("\n"), 4));
+            console.log();
+            console.log();
+            break
           case "MigrateOneToOneTableOp":
             console.log(`  ${bold(`Fix one-to-one table relations`)}`)
             console.log(


### PR DESCRIPTION
## Overview
While theoretically implemented in https://github.com/prisma/upgrade/pull/40 for https://github.com/prisma/upgrade/issues/38 , it turns out that the necessary operations were not printing, nor were they properly filtering the models and fields (was checking the `to` model instead of `fromField`). This fixes that